### PR TITLE
ci: automatically add issues to planning

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,15 @@
+name: Add issues to planning project
+
+on:
+  issues:
+    type: opened
+
+jobs:
+  add-to-project:
+    name: Add issue to planning project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@1.0.2
+        with:
+          project-url: https://github.com/orgs/teamsbc/projects/2
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
I'd like to try out GitHub's project features a bit for TeamSBC. This action automatically adds any newly opened issue to the planning.

Note that we can't use the project workflows offered by GitHub projects itself as they only allow one repository for non-enterprise customers. Hence we use a GitHub action to achieve the (hopefully) same result.