### PR TITLE
fedora: split `teamsbc-repos`

### DIFF
--- a/fedora/teamsbc-release/teamsbc-release.spec
+++ b/fedora/teamsbc-release/teamsbc-release.spec
@@ -3,7 +3,7 @@
 
 Name:           teamsbc-release
 Version:        %{dist_version}
-Release:        2
+Release:        3
 Summary:        Fedora TeamSBC Remix release files
 
 License:        MIT
@@ -61,13 +61,14 @@ Summary:    Base package for Fedora TeamSBC Remix Standard-specific default conf
 
 RemovePathPostfixes: .standard
 
-Provides: teamsbc-release = %{version}-%{release}
-Provides: teamsbc-release-variant = %{version}-%{release}
-Provides: system-release
-Provides: system-release(%{version})
+Provides:  teamsbc-release = %{version}-%{release}
+Provides:  teamsbc-release-variant = %{version}-%{release}
+Provides:  system-release
+Provides:  system-release(%{version})
 Conflicts: fedora-release
 Conflicts: fedora-release-identity
-Requires: teamsbc-release-common
+Requires:  teamsbc-release-common
+Requires:  teamsbc-repos-standard
 
 Recommends: teamsbc-release-identity-standard
 
@@ -173,6 +174,9 @@ EOF
 %{_prefix}/lib/os-release.standard
 
 %changelog
+* Thu Nov 06 2025 Simon de Vlieger <cmdr@supakeen.com> - %{fedora}-3
+- Dependency on `teamsbc-repos-standard` for the standard subpackage.
+
 * Mon Nov 03 2025 Simon de Vlieger <cmdr@supakeen.com> - %{fedora}-2
 - Dependency on `teamsbc-repos` for the common subpackage.
 

--- a/fedora/teamsbc-repos/teamsbc-repos.spec
+++ b/fedora/teamsbc-repos/teamsbc-repos.spec
@@ -2,7 +2,7 @@
 
 Name:           teamsbc-repos
 Version:        %{dist_version}
-Release:        1
+Release:        2
 Summary:        Fedora TeamSBC Remix package repositories
 
 License:        MIT
@@ -14,7 +14,22 @@ BuildArch:      noarch
 
 Source1:        teamsbc-base.repo
 
+Requires:       teamsbc-repos-common = %{version}-%{release}
+
 %description
+Fedora package repository files for yum and dnf.
+
+%package common
+Summary: Fedora TeamSBC Remix package repositories.
+
+%description common
+Fedora package repository files for yum and dnf.
+
+%package standard
+Summary:  Fedora TeamSBC Remix package repositories.
+Requires: teamsbc-repos-common
+
+%description standard
 Fedora package repository files for yum and dnf.
 
 %prep
@@ -27,10 +42,13 @@ install -m 644 %{_sourcedir}/teamsbc*repo %{buildroot}%{_sysconfdir}/yum.repos.d
 
 %check
 
-%files
+%files common
 %dir /etc/yum.repos.d
 %config(noreplace) /etc/yum.repos.d/teamsbc-base.repo
 
 %changelog
+* Thu Nov 06 2025 Simon de Vlieger <cmdr@supakeen.com> - %{fedora}-2
+- Create `-common` and `-standard` subpackage.
+
 * Mon Nov 03 2025 Simon de Vlieger <cmdr@supakeen.com> - %{fedora}-1
 - Initial setup of Fedora TeamSBC Remix's package repositories package.


### PR DESCRIPTION
Split the `teamsbc-repos` package into `-common` and `-standard`. The latter is empty at the moment.

This allows us to in the future provide specific repositories for variants.

Also updates the `teamsbc-variants` package to have the `-standard` variant require the `teamsbc-repos-standard` package.

This closes #4 [1].

[1]: https://github.com/teamsbc/packages/issues/4