### PR TITLE
fedora: change repo URLs to new COPR

### DIFF
--- a/fedora/teamsbc-repos/teamsbc-common.repo
+++ b/fedora/teamsbc-repos/teamsbc-common.repo
@@ -1,10 +1,10 @@
-[copr:copr.fedorainfracloud.org:supakeen:testing-do-not-look]
-name=Copr repo for testing-do-not-look owned by supakeen
-baseurl=https://download.copr.fedorainfracloud.org/results/supakeen/testing-do-not-look/fedora-$releasever-$basearch/
+[copr:copr.fedorainfracloud.org:group_teamsbc:fedora-common]
+name=Copr repo for fedora-common owned by @teamsbc
+baseurl=https://download.copr.fedorainfracloud.org/results/@teamsbc/fedora-common/fedora-$releasever-$basearch/
 type=rpm-md
 skip_if_unavailable=True
 gpgcheck=1
-gpgkey=https://download.copr.fedorainfracloud.org/results/supakeen/testing-do-not-look/pubkey.gpg
+gpgkey=https://download.copr.fedorainfracloud.org/results/@teamsbc/fedora-common/pubkey.gpg
 repo_gpgcheck=0
 enabled=1
 enabled_metadata=1

--- a/fedora/teamsbc-repos/teamsbc-repos.spec
+++ b/fedora/teamsbc-repos/teamsbc-repos.spec
@@ -2,7 +2,7 @@
 
 Name:           teamsbc-repos
 Version:        %{dist_version}
-Release:        2
+Release:        3
 Summary:        Fedora TeamSBC Remix package repositories
 
 License:        MIT
@@ -51,6 +51,9 @@ install -m 644 %{_sourcedir}/teamsbc*repo %{buildroot}%{_sysconfdir}/yum.repos.d
 %config(noreplace) /etc/yum.repos.d/teamsbc-standard.repo
 
 %changelog
+* Fri Nov 07 2025 Simon de Vlieger <cmdr@supakeen.com> - %{fedora}-2
+- Point to new COPR group repositories.
+
 * Thu Nov 06 2025 Simon de Vlieger <cmdr@supakeen.com> - %{fedora}-2
 - Create `-common` and `-standard` subpackage.
 

--- a/fedora/teamsbc-repos/teamsbc-standard.repo
+++ b/fedora/teamsbc-repos/teamsbc-standard.repo
@@ -1,10 +1,10 @@
-[copr:copr.fedorainfracloud.org:supakeen:testing-do-not-look]
-name=Copr repo for testing-do-not-look owned by supakeen
-baseurl=https://download.copr.fedorainfracloud.org/results/supakeen/testing-do-not-look/fedora-$releasever-$basearch/
+[copr:copr.fedorainfracloud.org:group_teamsbc:fedora-common]
+name=Copr repo for fedora-common owned by @teamsbc
+baseurl=https://download.copr.fedorainfracloud.org/results/@teamsbc/fedora-common/fedora-$releasever-$basearch/
 type=rpm-md
 skip_if_unavailable=True
 gpgcheck=1
-gpgkey=https://download.copr.fedorainfracloud.org/results/supakeen/testing-do-not-look/pubkey.gpg
+gpgkey=https://download.copr.fedorainfracloud.org/results/@teamsbc/fedora-common/pubkey.gpg
 repo_gpgcheck=0
 enabled=1
 enabled_metadata=1


### PR DESCRIPTION
Recently a TeamSBC FAS group was created and thus we now have a COPR group that can be maintained by multiple people. Our packages have been built in it so let's point at the new repository URLs.

---

This closes #7.